### PR TITLE
Fixed incorrect plot indexing in info_plot.cpp

### DIFF
--- a/pkgs/gui_interface/src/info_plot.cpp
+++ b/pkgs/gui_interface/src/info_plot.cpp
@@ -159,9 +159,9 @@ void InfoPlot::Render()
             }
 
             ImPlot::EndPlot();
-        }
 
-        p_idx++;
+            p_idx++;
+        }
     }
 
     if (active_plots > 3 && p_idx % 2 == 1)


### PR DESCRIPTION
When rendering the plots for the statistics menu, the bus voltage index counter was being incremented incorrectly, causing layout errors in certain circumstances, sometimes leading to crashes. The provided fix should fix that as it only increments when the bus voltage is actively rendered, matching the implementation for every other plot 